### PR TITLE
Added SIP and Trust Provider Hijacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ PS> Import-Module ./PersistenceHunter.ps1
 + Logon Scripts
 + Scheduled Tasks
 + Security Support Providers
++ SIP and Trust Provider Hijacking
 
 ## To-do 
 ##### Some of these won't be able to be done with PowerShell
@@ -47,7 +48,6 @@ PS> Import-Module ./PersistenceHunter.ps1
 + Server Software Component
 + Service Registry Permissions Weakness
 + Shortcut Modification
-+ SIP and Trust Provider Hijacking
 + System Firmware
 + Time Providers
 + Valid Accounts


### PR DESCRIPTION
Given an unauthorized change, and no prior presence/auditing setup on a machine, the most useful action to detect this is to show a user a list of registry entries (as described here https://attack.mitre.org/techniques/T1198/) sorted in descending order using the LastWriteTime. Most recent changes to a key or group of keys may indicate a malicious actor.